### PR TITLE
Method webroot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,3 +36,4 @@ certbot_keep_updated: true
 
 # Where to put Certbot when installing from source.
 certbot_dir: /opt/certbot
+certbot_webroot: /var/www/letsencrypt

--- a/tasks/create-cert-webroot.yml
+++ b/tasks/create-cert-webroot.yml
@@ -1,0 +1,13 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
+  register: letsencrypt_cert
+
+- name: Override certbot command variable to use webroot
+  include_vars: "webroot.yml"
+  when: not letsencrypt_cert.stat.exists
+
+- name: Generate new certificate if one doesn't exist.
+  command: "{{ certbot_create_command }}"
+  when: not letsencrypt_cert.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,5 +15,13 @@
   loop_control:
     loop_var: cert_item
 
+- include_tasks: create-cert-webroot.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'webroot'
+  loop_control:
+    loop_var: cert_item
+
 - import_tasks: renew-cron.yml
   when: certbot_auto_renew

--- a/vars/webroot.yml
+++ b/vars/webroot.yml
@@ -5,4 +5,3 @@ certbot_create_command: >-
   --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
-

--- a/vars/webroot.yml
+++ b/vars/webroot.yml
@@ -5,3 +5,4 @@ certbot_create_command: >-
   --noninteractive --agree-tos
   --email {{ cert_item.email | default(certbot_admin_email) }}
   -d {{ cert_item.domains | join(',') }}
+

--- a/vars/webroot.yml
+++ b/vars/webroot.yml
@@ -1,0 +1,7 @@
+---
+certbot_create_command: >-
+  {{ certbot_script }} certonly --webroot
+  --webroot-path {{ certbot_webroot }}
+  --noninteractive --agree-tos
+  --email {{ cert_item.email | default(certbot_admin_email) }}
+  -d {{ cert_item.domains | join(',') }}


### PR DESCRIPTION
This pull request contains additional method "webroot".

This allows to configure proxies against /var/www/letsencrypt directory to avoid web server restart, when it is critical.